### PR TITLE
feat: apply trim on blur

### DIFF
--- a/src/trim-value-accessor.ts
+++ b/src/trim-value-accessor.ts
@@ -31,6 +31,11 @@ export class TrimValueAccessor extends DefaultValueAccessor {
     this.onChange(val.trim());
   };
 
+  @HostListener('blur', ['$event.target.value'])
+  applyTrim (val: string) {
+    this.writeValue(val.trim());
+  };
+
   writeValue(value: any): void {
     if (typeof value === 'string') {
       value = value.trim();


### PR DESCRIPTION
This is to provide the trim behavior on blur, so that besides applying the value internally, the trimmed value is immediately reflected in the input. The most typical scenario handled is when user leaves untrimmed input and immediately submits the form.