### PR TITLE
Warn about use with Material Components

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,10 @@
 
 Angular's missing trim input functionality (equivalent of AngularJS `ng-trim`)
 
-**Caveat:** It's a drop-in solution, meaning it applies to all input fields as soon as this module is used.
+**Caveats:**
+
+* It's a drop-in solution, meaning it applies to all input fields as soon as this module is used.
+* It does not work with inputs that are already using another value accessor, since Angular only allows one value accessor per form control. This means it cannot be used with Angular Material inputs (the `matInput` directive uses a value accessor).
 
 ## Installation
 


### PR DESCRIPTION
It is very common for Angular apps to use [Angular's Material Design component library](https://github.com/angular/components), which does not offer trimming functionality, and most people (like me) won't realize that it's incompatible with this package, as evidenced by [the 3 issues](https://github.com/khashayar/ng-trim-value-accessor/issues/17) (perhaps more) related to this. Therefore, it seems fitting to offer an up-front alert that these two solutions won't play nice.